### PR TITLE
Add `CredentialsProvider.credentialsFile(AwsProfileName)`

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsProfileName.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsProfileName.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws
+
+/**
+  * Represents the name of a profile in the `~/.aws/config` file.
+  */
+final case class AwsProfileName(value: String) {
+  def isDefault: Boolean =
+    value == "default"
+}
+
+object AwsProfileName {
+  val default: AwsProfileName =
+    AwsProfileName("default")
+}

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -184,23 +184,42 @@ object CredentialsProvider {
 
   /**
     * Returns a new [[CredentialsProvider]] which reads credentials
-    * from `~/.aws/credentials` for the `default` profile.
+    * from `~/.aws/credentials` for a profile.
     *
     * The location of the credentials file can be set using either:
     *
     * - the `aws.sharedCredentialsFile` system property, or
-    * - the `AWS_SHARED_CREDENTIALS_FILE` environment variable.
+    * - the `AWS_SHARED_CREDENTIALS_FILE` environment variable, or
+    * - it will default to `~/.aws/credentials` if neither is set.
     *
     * The name of the profile can be set using either:
     *
     * - the `aws.profile` system property, or
-    * - the `AWS_PROFILE` environment variable.
+    * - the `AWS_PROFILE` environment variable, or
+    * - it will default to `default` if neither is set.
     *
     * Once credentials have successfully been read, the credentials
     * are cached indefinitely. This means subsequent updates to the
     * location, profile, or file will not be taken into account.
     */
   def credentialsFile[F[_]: Sync]: F[CredentialsProvider[F]] =
+    Profile.readOrDefault.flatMap(credentialsFile(_))
+
+    /**
+      * Returns a new [[CredentialsProvider]] which reads credentials
+      * from `~/.aws/credentials` for the specified profile.
+      *
+      * The location of the credentials file can be set using either:
+      *
+      * - the `aws.sharedCredentialsFile` system property, or
+      * - the `AWS_SHARED_CREDENTIALS_FILE` environment variable, or
+      * - it will default to `~/.aws/credentials` if neither is set.
+      *
+      * Once credentials have successfully been read, the credentials
+      * are cached indefinitely. This means subsequent updates to the
+      * location or file will not be taken into account.
+      */
+  def credentialsFile[F[_]: Sync](profileName: AwsProfileName): F[CredentialsProvider[F]] =
     Ref[F].of(Option.empty[Credentials]).map { ref =>
       new CredentialsProvider[F] {
         override val credentials: F[Credentials] =
@@ -209,24 +228,23 @@ object CredentialsProvider {
               credentials.pure
             case None =>
               for {
-                profile <- Profile.readOrDefault
                 credentialsFilePath <- SharedCredentialsFile.read
                   .map(_.toRight(MissingCredentials()))
                   .rethrow
                 _ <- ensureExists(credentialsFilePath)
                 credentialsFile <- readIniFile(credentialsFilePath)
                 accessKeyId <- credentialsFile
-                  .read(profile, "aws_access_key_id")
+                  .read(profileName.value, "aws_access_key_id")
                   .map(Credentials.AccessKeyId(_))
                   .toRight(MissingCredentials())
                   .liftTo
                 secretAccessKey <- credentialsFile
-                  .read(profile, "aws_secret_access_key")
+                  .read(profileName.value, "aws_secret_access_key")
                   .map(Credentials.SecretAccessKey(_))
                   .toRight(MissingCredentials())
                   .liftTo
                 sessionToken <- credentialsFile
-                  .read(profile, "aws_session_token")
+                  .read(profileName.value, "aws_session_token")
                   .map(Credentials.SessionToken(_))
                   .pure
                 credentials <- Credentials(accessKeyId, secretAccessKey, sessionToken).pure

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -48,7 +48,7 @@ import scala.concurrent.duration.*
   * - When running command-line applications, one typically requests
   *   temporary security credentials from the Security Token Service
   *   (STS) using the credentials in `~/.aws/credentials`, which can
-  *   be read by [[CredentialsProvider.credentialsFile]].
+  *   be read by `CredentialsProvider.credentialsFile`.
   * - When running a service in Elastic Container Service (ECS) or on
   *   Fargate, credentials are provided by a container endpoint, which
   *   can be read by [[CredentialsProvider.containerEndpoint]].
@@ -278,7 +278,7 @@ object CredentialsProvider {
     *
     * - [[CredentialsProvider.systemProperties]] for system properties,
     * - [[CredentialsProvider.environmentVariables]] for environment variables,
-    * - [[CredentialsProvider.credentialsFile]] for a shared credentials file,
+    * - `CredentialsProvider.credentialsFile` for a shared credentials file,
     * - [[CredentialsProvider.containerEndpoint]] for a container endpoint.
     *
     * Subsequent credential requests will continue to use the first

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
@@ -18,6 +18,7 @@ package com.magine.http4s.aws.internal
 
 import cats.effect.Sync
 import cats.syntax.all.*
+import com.magine.http4s.aws.AwsProfileName
 import com.magine.http4s.aws.Credentials
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -127,13 +128,13 @@ private[aws] object Setting {
   }
 
   object Profile
-    extends Setting.Default[String](
+    extends Setting.Default[AwsProfileName](
       envName = "AWS_PROFILE",
       propName = "aws.profile",
-      default = "default"
+      default = AwsProfileName.default
     ) {
-    override def parse[F[_]: Sync](value: String): F[String] =
-      Sync[F].pure(value)
+    override def parse[F[_]: Sync](value: String): F[AwsProfileName] =
+      Sync[F].pure(AwsProfileName(value))
   }
 
   object SecretAccessKey


### PR DESCRIPTION
This is to be able to specify the profile, for which to read credentials, directly in code instead of relying on system properties or environment variables.