### PR TITLE
Remove `Hashing` constraint for `CredentialsProvider.securityTokenService`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,15 @@ inThisBuild(
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17")),
     githubWorkflowTargetBranches := Seq("**"),
     licenses := Seq(License.Apache2),
-    mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("com.magine.http4s.aws.internal.*"),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[Problem]("com.magine.http4s.aws.internal.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.magine.http4s.aws.CredentialsProvider.securityTokenService"
+      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "com.magine.http4s.aws.CredentialsProvider.securityTokenService"
+      )
+    ),
     organization := "com.magine",
     organizationName := "Magine Pro",
     scalaVersion := scala3Version,

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ inThisBuild(
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     startYear := Some(2025),
-    tlBaseVersion := "6.1",
+    tlBaseVersion := "6.2",
     tlCiHeaderCheck := true,
     tlCiScalafixCheck := true,
     tlCiScalafmtCheck := true,


### PR DESCRIPTION
In #3, `Hashing` was accidentally added to `CredentialsProvider.securityTokenService` rather than being derived. This pull request removes the `Hashing` constraint in a binary compatible way. This is done by making the existing functions package private and adding new versions without the `Hashing` constraint. This change is not source compatible, but should be easy to fix for dependants. I've manually verified binary compatibility is maintained, so the MiMa exclusions should be safe.