### PR TITLE
Change `AwsSigning` and `AwsPresigning` to use `Hashing`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,9 @@ inThisBuild(
       ),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "com.magine.http4s.aws.AwsPresigning.apply"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.magine.http4s.aws.AwsSigning.signRequest"
       )
     ),
     organization := "com.magine",

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,12 @@ inThisBuild(
       ),
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
         "com.magine.http4s.aws.CredentialsProvider.securityTokenService"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.magine.http4s.aws.AwsPresigning.presignRequest"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "com.magine.http4s.aws.AwsPresigning.apply"
       )
     ),
     organization := "com.magine",

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
@@ -18,12 +18,14 @@ package com.magine.http4s.aws
 
 import cats.Applicative
 import cats.ApplicativeThrow
+import cats.effect.MonadCancelThrow
 import cats.effect.Temporal
 import cats.syntax.all.*
 import com.magine.aws.Region
 import com.magine.http4s.aws.headers.*
 import com.magine.http4s.aws.headers.`X-Amz-Algorithm`.`AWS4-HMAC-SHA256`
 import com.magine.http4s.aws.internal.*
+import fs2.hashing.Hashing
 import org.http4s.Request
 import scala.concurrent.duration.FiniteDuration
 
@@ -44,7 +46,7 @@ object AwsPresigning {
     * The presigning will target the specified region and
     * service, and use the specified expiry time.
     */
-  def apply[F[_]: Temporal](
+  def apply[F[_]: Temporal: Hashing](
     provider: CredentialsProvider[F],
     region: Region,
     serviceName: AwsServiceName,
@@ -62,7 +64,35 @@ object AwsPresigning {
             serviceName = serviceName,
             sessionToken = credentials.sessionToken
           )
-          presigned <- presignRequest(
+          presigned <- presignRequestHashing(
+            request = prepared,
+            secretAccessKey = credentials.secretAccessKey,
+            region = region,
+            serviceName = serviceName
+          )
+        } yield presigned
+    }
+
+  /* TODO: Remove for 7.0 release. */
+  private[aws] def apply[F[_]: Temporal](
+    provider: CredentialsProvider[F],
+    region: Region,
+    serviceName: AwsServiceName,
+    expiry: FiniteDuration
+  ): AwsPresigning[F] =
+    new AwsPresigning[F] {
+      override def presign(request: Request[F]): F[Request[F]] =
+        for {
+          credentials <- provider.credentials
+          prepared <- prepareRequest(
+            request = request,
+            expiry = expiry,
+            accessKeyId = credentials.accessKeyId,
+            region = region,
+            serviceName = serviceName,
+            sessionToken = credentials.sessionToken
+          )
+          presigned <- presignRequestLegacy(
             request = prepared,
             secretAccessKey = credentials.secretAccessKey,
             region = region,
@@ -116,11 +146,46 @@ object AwsPresigning {
     * The specified request should have required headers and
     * query parameters, as added by [[prepareRequest]].
     */
-  def presignRequest[F[_]: ApplicativeThrow](
+  def presignRequest[F[_]: MonadCancelThrow: Hashing](
     request: Request[F],
     secretAccessKey: Credentials.SecretAccessKey,
     region: Region,
-    serviceName: AwsServiceName,
+    serviceName: AwsServiceName
+  ): F[Request[F]] =
+    presignRequestHashing(request, secretAccessKey, region, serviceName)
+
+  /* TODO: Inline for 7.0 release. */
+  private def presignRequestHashing[F[_]: MonadCancelThrow: Hashing](
+    request: Request[F],
+    secretAccessKey: Credentials.SecretAccessKey,
+    region: Region,
+    serviceName: AwsServiceName
+  ): F[Request[F]] =
+    RequestDateTime.fromRequestQueryParam(request).flatMap { requestDateTime =>
+      val canonicalRequest = CanonicalRequest.fromRequestUnsignedPayload(request, serviceName)
+      val credentialScope = CredentialScope(region, requestDateTime.date, serviceName)
+      val signingContent = Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
+      for {
+        signingKey <- Signature.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
+        signature <- Signature.sign(signingKey, signingContent).map(_.value)
+      } yield `X-Amz-Signature`.putQueryParam(signature)(request)
+    }
+
+  /* TODO: Remove for 7.0 release. */
+  private[aws] def presignRequest[F[_]: ApplicativeThrow](
+    request: Request[F],
+    secretAccessKey: Credentials.SecretAccessKey,
+    region: Region,
+    serviceName: AwsServiceName
+  ): F[Request[F]] =
+    presignRequestLegacy(request, secretAccessKey, region, serviceName)
+
+  /* TODO: Remove for 7.0 release. */
+  private def presignRequestLegacy[F[_]: ApplicativeThrow](
+    request: Request[F],
+    secretAccessKey: Credentials.SecretAccessKey,
+    region: Region,
+    serviceName: AwsServiceName
   ): F[Request[F]] =
     RequestDateTime.fromRequestQueryParam(request).map { requestDateTime =>
       val canonicalRequest = CanonicalRequest.fromRequestUnsignedPayload(request, serviceName)

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
@@ -125,9 +125,9 @@ object AwsPresigning {
     RequestDateTime.fromRequestQueryParam(request).map { requestDateTime =>
       val canonicalRequest = CanonicalRequest.fromRequestUnsignedPayload(request, serviceName)
       val credentialScope = CredentialScope(region, requestDateTime.date, serviceName)
-      val signingContent = Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
-      val signingKey = Signature.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
-      val signature = Signature.sign(signingKey, signingContent).value
+      val signingContent = Signature.Legacy.signingContent(canonicalRequest, credentialScope, requestDateTime)
+      val signingKey = Signature.Legacy.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
+      val signature = Signature.Legacy.sign(signingKey, signingContent).value
       `X-Amz-Signature`.putQueryParam(signature)(request)
     }
 }

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
@@ -46,7 +46,7 @@ object AwsPresigning {
     * The presigning will target the specified region and
     * service, and use the specified expiry time.
     */
-  def apply[F[_]: Temporal: Hashing](
+  def apply[F[_]: Hashing: Temporal](
     provider: CredentialsProvider[F],
     region: Region,
     serviceName: AwsServiceName,
@@ -146,7 +146,7 @@ object AwsPresigning {
     * The specified request should have required headers and
     * query parameters, as added by [[prepareRequest]].
     */
-  def presignRequest[F[_]: MonadCancelThrow: Hashing](
+  def presignRequest[F[_]: Hashing: MonadCancelThrow](
     request: Request[F],
     secretAccessKey: Credentials.SecretAccessKey,
     region: Region,
@@ -155,7 +155,7 @@ object AwsPresigning {
     presignRequestHashing(request, secretAccessKey, region, serviceName)
 
   /* TODO: Inline for 7.0 release. */
-  private def presignRequestHashing[F[_]: MonadCancelThrow: Hashing](
+  private def presignRequestHashing[F[_]: Hashing: MonadCancelThrow](
     request: Request[F],
     secretAccessKey: Credentials.SecretAccessKey,
     region: Region,

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsSigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsSigning.scala
@@ -112,9 +112,9 @@ object AwsSigning {
       RequestDateTime.fromRequest(request)
     ).mapN { (canonicalRequest, requestDateTime) =>
       val credentialScope = CredentialScope(region, requestDateTime.date, serviceName)
-      val signingContent = Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
-      val signingKey = Signature.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
-      val signature = Signature.sign(signingKey, signingContent)
+      val signingContent = Signature.Legacy.signingContent(canonicalRequest, credentialScope, requestDateTime)
+      val signingKey = Signature.Legacy.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
+      val signature = Signature.Legacy.sign(signingKey, signingContent)
       Authorization.putIfAbsent(request, accessKeyId, canonicalRequest, credentialScope, signature)
     }
 }

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Signature.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Signature.scala
@@ -76,7 +76,7 @@ private[aws] object Signature {
     }
 
   object Legacy {
-    private val algorithm: String = "HmacSHA256"
+    val algorithm: String = "HmacSHA256"
 
     def sign(key: SecretKeySpec, bytes: Array[Byte]): Signature =
       Signature(Hex.encodeHex(signWithKey(key, bytes)))

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Signature.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Signature.scala
@@ -33,7 +33,7 @@ import scala.util.chaining.*
 private[aws] final case class Signature(value: String)
 
 private[aws] object Signature {
-  def sign[F[_]: MonadCancelThrow: Hashing](key: Chunk[Byte], bytes: Chunk[Byte]): F[Signature] =
+  def sign[F[_]: Hashing: MonadCancelThrow](key: Chunk[Byte], bytes: Chunk[Byte]): F[Signature] =
     signWithKey(key, bytes).map(hash => Signature(Hex.encodeHex(hash.bytes.toArray)))
 
   def signingContent(
@@ -46,7 +46,7 @@ private[aws] object Signature {
         .getBytes(UTF_8)
     )
 
-  def signingKey[F[_]: MonadCancelThrow: Hashing](
+  def signingKey[F[_]: Hashing: MonadCancelThrow](
     region: Region,
     requestDate: RequestDate,
     secretAccessKey: Credentials.SecretAccessKey,
@@ -64,7 +64,7 @@ private[aws] object Signature {
       .flatMap(sign(Chunk.array("aws4_request".getBytes(UTF_8))))
   }
 
-  private def signWithKey[F[_]: MonadCancelThrow: Hashing](
+  private def signWithKey[F[_]: Hashing: MonadCancelThrow](
     key: Chunk[Byte],
     bytes: Chunk[Byte]
   ): F[Hash] =

--- a/modules/core/shared/src/test/scala/com/magine/http4s/aws/internal/SignatureSuite.scala
+++ b/modules/core/shared/src/test/scala/com/magine/http4s/aws/internal/SignatureSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+import cats.effect.IO
+import com.magine.aws.Region
+import com.magine.http4s.aws.AwsServiceName
+import com.magine.http4s.aws.Credentials
+import com.magine.http4s.aws.internal.Signature.Legacy.algorithm
+import fs2.Chunk
+import java.time.LocalDate
+import javax.crypto.spec.SecretKeySpec
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
+
+final class SignatureSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
+  test("Signature.sign consistent with legacy") {
+    val gen =
+      for {
+        key <- arbitrary[Array[Byte]]
+        if key.nonEmpty
+        bytes <- arbitrary[Array[Byte]]
+      } yield (key, bytes)
+
+    PropF.forAllF(gen) { case (key, bytes) =>
+      for {
+        actual <- Signature.sign[IO](Chunk.array(key), Chunk.array(bytes))
+        expected = Signature.Legacy.sign(new SecretKeySpec(key, algorithm), bytes)
+        _ <- IO(assertEquals(actual, expected))
+      } yield ()
+    }
+  }
+
+  test("Signature.signingKey consistent with legacy") {
+    val gen =
+      for {
+        region <- Gen.oneOf(Gen.oneOf(Region.values), arbitrary[String].map(Region(_)))
+        requestDate <- arbitrary[LocalDate].map(RequestDate(_))
+        secretAccessKey <- arbitrary[String].map(Credentials.SecretAccessKey(_))
+        serviceName <- arbitrary[String].map(AwsServiceName(_))
+      } yield (region, requestDate, secretAccessKey, serviceName)
+
+    PropF.forAllF(gen) { case (region, requestDate, secretAccessKey, serviceName) =>
+      for {
+        actual <- Signature.signingKey[IO](region, requestDate, secretAccessKey, serviceName)
+        expected = Signature.Legacy.signingKey(region, requestDate, secretAccessKey, serviceName)
+        _ <- IO(assertEquals(actual, Chunk.array(expected.getEncoded)))
+      } yield ()
+    }
+  }
+}


### PR DESCRIPTION
Parts of  `AwsSigning` and `AwsPresigning` currently rely on `javax.crypto`, which is not available on Scala.js and Scala Native. This pull request switches to use `fs2.Hashing` (which is available for both Scala.js and Scala Native) while maintaining binary compatibility (but breaking source compatibility).