### PR TITLE
Change to use `Hashing` instead of `MessageDigest`

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
@@ -165,7 +165,7 @@ object AwsPresigning {
       requestDateTime <- RequestDateTime.fromRequestQueryParam(request)
       canonicalRequest = CanonicalRequest.fromRequestUnsignedPayload(request, serviceName)
       credentialScope = CredentialScope(region, requestDateTime.date, serviceName)
-      signingContent = Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
+      signingContent <- Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
       signingKey <- Signature.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
       signature <- Signature.sign(signingKey, signingContent).map(_.value)
     } yield `X-Amz-Signature`.putQueryParam(signature)(request)

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsSigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsSigning.scala
@@ -122,7 +122,7 @@ object AwsSigning {
       canonicalRequest <- CanonicalRequest.fromRequest(request, serviceName)
       requestDateTime <- RequestDateTime.fromRequest(request)
       credentialScope = CredentialScope(region, requestDateTime.date, serviceName)
-      signingContent = Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
+      signingContent <- Signature.signingContent(canonicalRequest, credentialScope, requestDateTime)
       signingKey <- Signature.signingKey(region, requestDateTime.date, secretAccessKey, serviceName)
       signature <- Signature.sign(signingKey, signingContent)
     } yield Authorization.putIfAbsent(request, accessKeyId, canonicalRequest, credentialScope, signature)

--- a/modules/core/shared/src/test/scala/com/magine/http4s/aws/internal/package.scala
+++ b/modules/core/shared/src/test/scala/com/magine/http4s/aws/internal/package.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws
+
+import com.magine.aws.Region
+import java.time.Instant
+import java.time.LocalDate
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+
+package object internal {
+  val canonicalRequestGen: Gen[CanonicalRequest] =
+    for {
+      httpMethod <- arbitrary[String]
+      canonicalUri <- arbitrary[String]
+      canonicalQueryString <- arbitrary[String]
+      canonicalHeaders <- arbitrary[String]
+      signedHeaders <- arbitrary[String]
+      hashedPayload <- arbitrary[String]
+    } yield CanonicalRequest(
+      httpMethod = httpMethod,
+      canonicalUri = canonicalUri,
+      canonicalQueryString = canonicalQueryString,
+      canonicalHeaders = canonicalHeaders,
+      signedHeaders = signedHeaders,
+      hashedPayload = hashedPayload
+    )
+
+  implicit val canonicalRequestArbitrary: Arbitrary[CanonicalRequest] =
+    Arbitrary(canonicalRequestGen)
+
+  val credentialScopeGen: Gen[CredentialScope] =
+    for {
+      region <- arbitrary[Region]
+      requestDate <- arbitrary[RequestDate]
+      serviceName <- arbitrary[AwsServiceName]
+    } yield CredentialScope(
+      region = region,
+      requestDate = requestDate,
+      serviceName = serviceName
+    )
+
+  implicit val credentialScopeArbitrary: Arbitrary[CredentialScope] =
+    Arbitrary(credentialScopeGen)
+
+  val requestDateGen: Gen[RequestDate] =
+    arbitrary[LocalDate].map(RequestDate(_))
+
+  implicit val requestDateArbitrary: Arbitrary[RequestDate] =
+    Arbitrary(requestDateGen)
+
+  val requestDateTimeGen: Gen[RequestDateTime] =
+    arbitrary[Instant].map(RequestDateTime(_))
+
+  implicit val requestDateTimeArbitrary: Arbitrary[RequestDateTime] =
+    Arbitrary(requestDateTimeGen)
+}

--- a/modules/core/shared/src/test/scala/com/magine/http4s/aws/package.scala
+++ b/modules/core/shared/src/test/scala/com/magine/http4s/aws/package.scala
@@ -28,43 +28,43 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 
 package object aws {
-  implicit val awsProfileRoleArnGen: Gen[AwsProfile.RoleArn] =
+  val awsProfileRoleArnGen: Gen[AwsProfile.RoleArn] =
     arbitrary[String].map(AwsProfile.RoleArn(_))
 
   implicit val awsProfileRoleArnArbitrary: Arbitrary[AwsProfile.RoleArn] =
     Arbitrary(awsProfileRoleArnGen)
 
-  implicit val awsProfileRoleSessionNameGen: Gen[AwsProfile.RoleSessionName] =
+  val awsProfileRoleSessionNameGen: Gen[AwsProfile.RoleSessionName] =
     arbitrary[String].map(AwsProfile.RoleSessionName(_))
 
   implicit val awsProfileRoleSessionNameArbitrary: Arbitrary[AwsProfile.RoleSessionName] =
     Arbitrary(awsProfileRoleSessionNameGen)
 
-  implicit val awsProfileDurationSecondsGen: Gen[AwsProfile.DurationSeconds] =
+  val awsProfileDurationSecondsGen: Gen[AwsProfile.DurationSeconds] =
     arbitrary[Int].map(AwsProfile.DurationSeconds(_))
 
   implicit val awsProfileDurationSecondsArbitrary: Arbitrary[AwsProfile.DurationSeconds] =
     Arbitrary(awsProfileDurationSecondsGen)
 
-  implicit val mfaSerialGen: Gen[MfaSerial] =
+  val mfaSerialGen: Gen[MfaSerial] =
     arbitrary[String].map(MfaSerial(_))
 
   implicit val mfaSerialArbitrary: Arbitrary[MfaSerial] =
     Arbitrary(mfaSerialGen)
 
-  implicit val regionGen: Gen[Region] =
+  val regionGen: Gen[Region] =
     Gen.oneOf(Region.values)
 
   implicit val regionArbitrary: Arbitrary[Region] =
     Arbitrary(regionGen)
 
-  implicit val awsProfileNameGen: Gen[AwsProfileName] =
+  val awsProfileNameGen: Gen[AwsProfileName] =
     arbitrary[String].map(AwsProfileName(_))
 
   implicit val awsProfileNameArbitrary: Arbitrary[AwsProfileName] =
     Arbitrary(awsProfileNameGen)
 
-  implicit val awsProfileGen: Gen[AwsProfile] =
+  val awsProfileGen: Gen[AwsProfile] =
     for {
       profileName <- arbitrary[AwsProfileName]
       roleArn <- arbitrary[Option[AwsProfile.RoleArn]]
@@ -86,7 +86,7 @@ package object aws {
   implicit val awsProfileArbitrary: Arbitrary[AwsProfile] =
     Arbitrary(awsProfileGen)
 
-  implicit val awsProfileResolvedGen: Gen[AwsProfileResolved] =
+  val awsProfileResolvedGen: Gen[AwsProfileResolved] =
     for {
       profileName <- arbitrary[AwsProfileName]
       roleArn <- arbitrary[AwsProfile.RoleArn]
@@ -108,25 +108,31 @@ package object aws {
   implicit val awsProfileResolvedArbitrary: Arbitrary[AwsProfileResolved] =
     Arbitrary(awsProfileResolvedGen)
 
-  implicit val credentialsAccessKeyIdGen: Gen[Credentials.AccessKeyId] =
+  val awsServiceNameGen: Gen[AwsServiceName] =
+    arbitrary[String].map(AwsServiceName(_))
+
+  implicit val awsServiceNameArbitrary: Arbitrary[AwsServiceName] =
+    Arbitrary(awsServiceNameGen)
+
+  val credentialsAccessKeyIdGen: Gen[Credentials.AccessKeyId] =
     arbitrary[String].map(Credentials.AccessKeyId(_))
 
   implicit val credentialsAccessKeyIdArbtirary: Arbitrary[Credentials.AccessKeyId] =
     Arbitrary(credentialsAccessKeyIdGen)
 
-  implicit val credentialsSecretAccessKeyGen: Gen[Credentials.SecretAccessKey] =
+  val credentialsSecretAccessKeyGen: Gen[Credentials.SecretAccessKey] =
     arbitrary[String].map(Credentials.SecretAccessKey(_))
 
   implicit val credentialsSecretAccessKeyArbitrary: Arbitrary[Credentials.SecretAccessKey] =
     Arbitrary(credentialsSecretAccessKeyGen)
 
-  implicit val credentialsSessionTokenGen: Gen[Credentials.SessionToken] =
+  val credentialsSessionTokenGen: Gen[Credentials.SessionToken] =
     arbitrary[String].map(Credentials.SessionToken(_))
 
   implicit val credentialsSessionTokenArbitrary: Arbitrary[Credentials.SessionToken] =
     Arbitrary(credentialsSessionTokenGen)
 
-  implicit val credentialsGen: Gen[Credentials] =
+  val credentialsGen: Gen[Credentials] =
     for {
       accessKeyId <- arbitrary[Credentials.AccessKeyId]
       secretAccessKey <- arbitrary[Credentials.SecretAccessKey]
@@ -144,19 +150,19 @@ package object aws {
   def awsCredentialsCacheFileName(profile: AwsProfileResolved): AwsCredentialsCache.FileName =
     AwsCredentialsCache.FileName.fromProfile[SyncIO](profile).unsafeRunSync()
 
-  implicit val awsCredentialsCacheFileNameGen: Gen[AwsCredentialsCache.FileName] =
+  val awsCredentialsCacheFileNameGen: Gen[AwsCredentialsCache.FileName] =
     arbitrary[AwsProfileResolved].flatMap(awsCredentialsCacheFileName(_))
 
   implicit val awsCredentialsCacheFileNameArbitrary: Arbitrary[AwsCredentialsCache.FileName] =
     Arbitrary(awsCredentialsCacheFileNameGen)
 
-  implicit val awsAssumedRoleAssumedRoleIdGen: Gen[AwsAssumedRole.AssumedRoleId] =
+  val awsAssumedRoleAssumedRoleIdGen: Gen[AwsAssumedRole.AssumedRoleId] =
     arbitrary[String].map(AwsAssumedRole.AssumedRoleId(_))
 
   implicit val awsAssumedRoleAssumedRoleIdArbitrary: Arbitrary[AwsAssumedRole.AssumedRoleId] =
     Arbitrary(awsAssumedRoleAssumedRoleIdGen)
 
-  implicit val awsAssumedRoleAssumedRoleArnGen: Gen[AwsAssumedRole.AssumedRoleArn] =
+  val awsAssumedRoleAssumedRoleArnGen: Gen[AwsAssumedRole.AssumedRoleArn] =
     arbitrary[String].map(AwsAssumedRole.AssumedRoleArn(_))
 
   implicit val awsAssumedRoleAssumedRoleArnArbitrary: Arbitrary[AwsAssumedRole.AssumedRoleArn] =
@@ -203,7 +209,7 @@ package object aws {
       assumedRole <- awsAssumedRoleGen(expiration, profile)
     } yield assumedRole
 
-  implicit val awsAssumedRoleGen: Gen[AwsAssumedRole] =
+  val awsAssumedRoleGen: Gen[AwsAssumedRole] =
     for {
       expiration <- arbitrary[Instant]
       profile <- arbitrary[AwsProfileResolved]
@@ -213,7 +219,7 @@ package object aws {
   implicit val awsAssumedRoleArbitrary: Arbitrary[AwsAssumedRole] =
     Arbitrary(awsAssumedRoleGen)
 
-  implicit val tokenCodeGen: Gen[TokenCode] =
+  val tokenCodeGen: Gen[TokenCode] =
     for {
       digits <- Gen.listOfN(6, Gen.numChar).map(_.mkString)
       tokenCode <- TokenCode(digits).map(Gen.const).getOrElse(Gen.fail)

--- a/modules/core/shared/src/test/scala/com/magine/http4s/aws/package.scala
+++ b/modules/core/shared/src/test/scala/com/magine/http4s/aws/package.scala
@@ -140,7 +140,7 @@ package object aws {
   implicit val credentialsArbitrary: Arbitrary[Credentials] =
     Arbitrary(credentialsGen)
 
-  /* The effect here is to capture `MessageDigest` possibly being unavailable. */
+  /* The effect here is to capture `Hashing` possibly being unavailable. */
   def awsCredentialsCacheFileName(profile: AwsProfileResolved): AwsCredentialsCache.FileName =
     AwsCredentialsCache.FileName.fromProfile[SyncIO](profile).unsafeRunSync()
 


### PR DESCRIPTION
Follow-up to #17, this pull request replaces internal usages of `MessageDigest` with `fs2.hashing.Hashing`.