### PR TITLE
Change to inline `Clock[F].realTimeInstant`

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsPresigning.scala
@@ -26,6 +26,7 @@ import com.magine.http4s.aws.headers.*
 import com.magine.http4s.aws.headers.`X-Amz-Algorithm`.`AWS4-HMAC-SHA256`
 import com.magine.http4s.aws.internal.*
 import fs2.hashing.Hashing
+import java.time.Instant
 import org.http4s.Request
 import scala.concurrent.duration.FiniteDuration
 
@@ -127,7 +128,7 @@ object AwsPresigning {
     sessionToken: Option[Credentials.SessionToken]
   ): F[Request[F]] =
     for {
-      now <- Temporal[F].realTimeInstant
+      now <- Temporal[F].realTime.map(d => Instant.EPOCH.plusNanos(d.toNanos))
       credential = `X-Amz-Credential`(accessKeyId, now, region, serviceName)
       prepared <- Host
         .putIfAbsent(request)

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/headers/X-Amz-Date.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/headers/X-Amz-Date.scala
@@ -59,7 +59,8 @@ object `X-Amz-Date` {
       .leftMap(_ => ParseFailure("Invalid X-Amz-Date header", s))
 
   def put[F[_]: Temporal](request: Request[F]): F[Request[F]] =
-    Temporal[F].realTimeInstant
+    Temporal[F].realTime
+      .map(d => Instant.EPOCH.plusNanos(d.toNanos))
       .map(`X-Amz-Date`(_))
       .map(request.putHeaders(_))
 

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsProfile.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsProfile.scala
@@ -24,6 +24,7 @@ import cats.syntax.all.*
 import com.magine.aws.Region
 import com.magine.http4s.aws.AwsProfileName
 import com.magine.http4s.aws.MfaSerial
+import java.time.Instant
 
 /**
   * Represents a profile in the `~/.aws/config` file.
@@ -50,9 +51,10 @@ private[aws] object AwsProfile {
     def default[F[_]](
       implicit F: Clock[F]
     ): F[RoleSessionName] =
-      F.applicative.map(F.realTimeInstant)(now =>
+      F.applicative.map(F.realTime) { realTime =>
+        val now = Instant.EPOCH.plusNanos(realTime.toNanos)
         RoleSessionName(s"http4s-aws-session-${now.getEpochSecond}")
-      )
+      }
   }
 
   final case class DurationSeconds(value: Int)


### PR DESCRIPTION
`Clock[F].realTimeInstant` is not available on Scala.js, so this pull request inlines the definition.