### PR TITLE
Change to use `fs2.io.file` instead of `java.nio.file`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,22 +25,16 @@ inThisBuild(
     githubWorkflowTargetBranches := Seq("**"),
     licenses := Seq(License.Apache2),
     mimaBinaryIssueFilters ++= Seq(
+      // format: off
       ProblemFilters.exclude[Problem]("com.magine.http4s.aws.internal.*"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "com.magine.http4s.aws.CredentialsProvider.securityTokenService"
-      ),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "com.magine.http4s.aws.CredentialsProvider.securityTokenService"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "com.magine.http4s.aws.AwsPresigning.presignRequest"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "com.magine.http4s.aws.AwsPresigning.apply"
-      ),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "com.magine.http4s.aws.AwsSigning.signRequest"
-      )
+      /* TODO: Remove for 7.0 release. */
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.CredentialsProvider.securityTokenService"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.magine.http4s.aws.CredentialsProvider.securityTokenService"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.AwsPresigning.presignRequest"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.AwsPresigning.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.AwsSigning.signRequest"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.magine.http4s.aws.CredentialsProvider.credentialsFile")
+      // format: on
     ),
     organization := "com.magine",
     organizationName := "Magine Pro",

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -282,7 +282,7 @@ object CredentialsProvider {
             .readAll(path)
             .through(utf8.decode)
             .compile
-            .foldMonoid
+            .string
             .adaptError { case _: NoSuchFileException => MissingCredentials() }
             .flatMap(IniFile.parse(_).leftMap(failedToParse(path, _)).liftTo[F])
 

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsConfig.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsConfig.scala
@@ -57,7 +57,7 @@ private[aws] object AwsConfig {
           .readAll(path)
           .through(utf8.decode)
           .compile
-          .foldMonoid
+          .string
           .adaptError { case _: NoSuchFileException => MissingCredentials() }
           .flatMap(IniFile.parse(_).leftMap(failedToParse(path, _)).liftTo[F])
 

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsCredentialsCache.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsCredentialsCache.scala
@@ -73,7 +73,7 @@ private[aws] object AwsCredentialsCache {
               .readAll(path)
               .through(utf8.decode)
               .compile
-              .foldMonoid
+              .string
               .flatMap(decode[AwsAssumedRole](_).map(_.some).liftTo[F])
               .recover { case _: NoSuchFileException => none }
           }


### PR DESCRIPTION
Replaces usages of `java.nio.file` with `fs2.io.file`, since the latter works on Scala.js.