### PR TITLE
Add `TokenCodeProvider.console` using `Console` and `fs2.io`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,13 +27,14 @@ inThisBuild(
     mimaBinaryIssueFilters ++= Seq(
       // format: off
       ProblemFilters.exclude[Problem]("com.magine.http4s.aws.internal.*"),
-      /* TODO: Remove for 7.0 release. */
+      /* TODO: Remove below filters for 7.0 release. */
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.CredentialsProvider.securityTokenService"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.magine.http4s.aws.CredentialsProvider.securityTokenService"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.AwsPresigning.presignRequest"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.AwsPresigning.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.magine.http4s.aws.AwsSigning.signRequest"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.magine.http4s.aws.CredentialsProvider.credentialsFile")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.magine.http4s.aws.CredentialsProvider.credentialsFile"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.magine.http4s.aws.TokenCodeProvider.default")
       // format: on
     ),
     organization := "com.magine",

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -407,7 +407,7 @@ object CredentialsProvider {
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
-        tokenCodeProvider = TokenCodeProvider.default[F],
+        tokenCodeProvider = TokenCodeProvider.console[F],
         credentialsCache = AwsCredentialsCache.default[F],
         sts = AwsSts.fromClient(client, provider, profile.region)
       )
@@ -424,7 +424,7 @@ object CredentialsProvider {
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
-        tokenCodeProvider = TokenCodeProvider.default[F],
+        tokenCodeProvider = TokenCodeProvider.console[F],
         credentialsCache = AwsCredentialsCache.default[F],
         sts = AwsSts.fromClient(client, provider, profile.region)
       )
@@ -490,7 +490,7 @@ object CredentialsProvider {
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
-        tokenCodeProvider = TokenCodeProvider.default[F],
+        tokenCodeProvider = TokenCodeProvider.console[F],
         credentialsCache = AwsCredentialsCache.default[F],
         sts = AwsSts.fromClient(client, provider, profile.region)
       )
@@ -507,7 +507,7 @@ object CredentialsProvider {
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
-        tokenCodeProvider = TokenCodeProvider.default[F],
+        tokenCodeProvider = TokenCodeProvider.console[F],
         credentialsCache = AwsCredentialsCache.default[F],
         sts = AwsSts.fromClient(client, provider, profile.region)
       )

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/InvalidTokenCode.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/InvalidTokenCode.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws
+
+import scala.util.control.NoStackTrace
+
+/**
+  * Exception raised by [[TokenCodeProvider]]s to indicate
+  * that a provided MFA code is not a valid [[TokenCode]].
+  */
+final case class InvalidTokenCode() extends RuntimeException with NoStackTrace {
+  override def getMessage: String = "Invalid MFA code, must be 6 digits"
+}


### PR DESCRIPTION
This is to have a default `TokenCodeProvider` which also works on Scala.js.