### PR TITLE
Change `AwsAssumedRole` to parse ISO 8601 timestamps

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsAssumedRole.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsAssumedRole.scala
@@ -66,7 +66,8 @@ private[aws] object AwsAssumedRole {
         sessionToken <- c.downField("Credentials").get[Credentials.SessionToken]("SessionToken")
         expirationField = c.downField("Credentials").downField("Expiration")
         expirationEpochSecond = expirationField.as[Long].map(Instant.ofEpochSecond)
-        expiration <- expirationEpochSecond.orElse(expirationField.as[Instant])
+        expirationIso8601 = expirationField.as(Iso8601.decoder)
+        expiration <- expirationEpochSecond.orElse(expirationIso8601)
         assumedRoleId <- c.downField("AssumedRoleUser").get[AssumedRoleId]("AssumedRoleId")
         assumedRoleArn <- c.downField("AssumedRoleUser").get[AssumedRoleArn]("Arn")
       } yield AwsAssumedRole(


### PR DESCRIPTION
The default `Decoder[Instant]` on Scala.js does not support the expected format.