### PR TITLE
Change to use `cats.effect.std.Env` for settings

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
@@ -19,6 +19,7 @@ package com.magine.http4s.aws.internal
 import cats.effect.Async
 import cats.effect.Sync
 import cats.effect.std.Env
+import cats.effect.std.SystemProperties
 import cats.syntax.all.*
 import com.magine.aws.Region
 import com.magine.http4s.aws.AwsProfileName
@@ -65,9 +66,7 @@ private[aws] object Setting {
     def parse(value: String): F[A]
 
     final def prop: F[Option[A]] =
-      Sync[F]
-        .delay(Option(System.getProperty(propName)))
-        .flatMap(_.traverse(parse))
+      SystemProperties.make[F].get(propName).flatMap(_.traverse(parse))
 
     final def read: F[Option[A]] =
       prop

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
@@ -18,6 +18,7 @@ package com.magine.http4s.aws.internal
 
 import cats.effect.Async
 import cats.effect.Sync
+import cats.effect.std.Env
 import cats.syntax.all.*
 import com.magine.aws.Region
 import com.magine.http4s.aws.AwsProfileName
@@ -56,9 +57,7 @@ private[aws] object Setting {
     propName: String
   ) extends Setting[F, A] {
     final def env: F[Option[A]] =
-      Sync[F]
-        .delay(Option(System.getenv(envName)))
-        .flatMap(_.traverse(parse))
+      Env.make[F].get(envName).flatMap(_.traverse(parse))
 
     def fallback: F[Option[A]] =
       Sync[F].pure(None)


### PR DESCRIPTION
This is to enable environment variables on Scala.js. Also changes to `cats.effect.std.SystemProperties` for consistency.