### PR TITLE
Change to prepare for signing chunked uploads

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsSigning.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/AwsSigning.scala
@@ -93,6 +93,7 @@ object AwsSigning {
       .flatMap(`X-Amz-Content-SHA256`.putIfAbsent[F])
       .flatMap(`X-Amz-Date`.putIfAbsent[F])
       .map(`X-Amz-Security-Token`.putIfAbsent[F](sessionToken))
+      .map(`Content-Encoding`.putIfChunked[F])
 
   /**
     * Returns a signed request by adding an `Authorization`

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/headers/Content-Encoding.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/headers/Content-Encoding.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.headers
+
+import org.http4s.ContentCoding
+import org.http4s.Request
+
+private[aws] object `Content-Encoding` {
+  private type `Content-Encoding` = org.http4s.headers.`Content-Encoding`
+  private val `Content-Encoding` = org.http4s.headers.`Content-Encoding`
+
+  val `aws-chunked`: `Content-Encoding` =
+    `Content-Encoding`(ContentCoding.unsafeFromString("aws-chunked"))
+
+  def putIfChunked[F[_]](request: Request[F]): Request[F] =
+    if (request.isChunked) request.putHeaders(`aws-chunked`) else request
+}

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/headers/X-Amz-Decoded-Content-Length.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/headers/X-Amz-Decoded-Content-Length.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.headers
+
+import org.http4s.Header
+import org.http4s.ParseFailure
+import org.http4s.ParseResult
+import org.http4s.Request
+import org.typelevel.ci.*
+
+final case class `X-Amz-Decoded-Content-Length`(value: Long)
+
+object `X-Amz-Decoded-Content-Length` {
+  def get[F[_]](request: Request[F]): Option[`X-Amz-Decoded-Content-Length`] =
+    request.headers.get[`X-Amz-Decoded-Content-Length`]
+
+  def parse(s: String): ParseResult[`X-Amz-Decoded-Content-Length`] =
+    s.toLongOption.map(apply).toRight {
+      ParseFailure("Invalid X-Amz-Decoded-Content-Length header", s)
+    }
+
+  def put[F[_]](value: Long)(request: Request[F]): Request[F] =
+    request.putHeaders(apply(value))
+
+  def putIfAbsent[F[_]](value: Long)(request: Request[F]): Request[F] =
+    if (request.headers.contains[`X-Amz-Decoded-Content-Length`]) request else put(value)(request)
+
+  implicit val headerInstance: Header[`X-Amz-Decoded-Content-Length`, Header.Single] =
+    Header.createRendered(ci"X-Amz-Decoded-Content-Length", _.value, parse)
+}


### PR DESCRIPTION
This pull request does some preparatory work to support [signing of chunked uploads](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html). Unfortunately, http4s 0.x does not support multiple codings in `Content-Encoding` ([http4s#2684](https://github.com/http4s/http4s/issues/2684)), so we have to use `aws-chunked` as the only coding at the moment.