### PR TITLE
Fallback to read token from file

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -167,14 +167,14 @@ object CredentialsProvider {
           .adaptError { case _: NoSuchFileException => MissingCredentials() }
 
       ContainerAuthorizationTokenFile[F].read
-        .flatMap {
+        .flatMap[Option[Header.Raw]] {
           case Some(path) =>
             for {
               s <- readFile(path)
             } yield Some(Header.Raw(ci"Authorization", s))
-          case None => None.pure[F]
+          case None => none[Header.Raw].pure[F]
         }
-        .recover { case _ => None }
+        .recover { case _ => none[Header.Raw] }
     }
 
     def requestCredentials: F[ExpiringCredentials] =

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -171,7 +171,7 @@ object CredentialsProvider {
           case Some(path) =>
             for {
               s <- readFile(path)
-            } yield Some(Header.Raw(ci"Authorization", s))
+            } yield Some(Header.Raw(ci"Authorization", s.trim))
           case None => none[Header.Raw].pure[F]
         }
         .recover { case _ => none[Header.Raw] }

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -166,13 +166,15 @@ object CredentialsProvider {
           .string
           .adaptError { case _: NoSuchFileException => MissingCredentials() }
 
-      ContainerAuthorizationTokenFile[F].read.flatMap {
-        case Some(path) =>
-          for {
-            s <- readFile(path)
-          } yield Some(Header.Raw(ci"Authorization", s))
-        case None => Async[F].pure(None)
-      }
+      ContainerAuthorizationTokenFile[F].read
+        .flatMap {
+          case Some(path) =>
+            for {
+              s <- readFile(path)
+            } yield Some(Header.Raw(ci"Authorization", s))
+          case None => None.pure[F]
+        }
+        .recover { case _ => None }
     }
 
     def requestCredentials: F[ExpiringCredentials] =

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -44,14 +44,14 @@ import fs2.text.utf8
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import org.http4s.Header
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Uri
 import org.http4s.client.Client
+import org.typelevel.ci.*
 import scala.annotation.nowarn
 import scala.concurrent.duration.*
-import org.http4s.Header
-import org.typelevel.ci._
 
 /**
   * Capability to return [[Credentials]] from one or multiple sources.

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
@@ -119,6 +119,15 @@ private[aws] object Setting {
         Header.Raw(ci"Authorization", value).pure
     }
 
+  def ContainerAuthorizationTokenFile[F[_]: Async]: Setting[F, Path] =
+    new Setting.Standard[F, Path](
+      envName = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+      propName = "aws.containerAuthorizationTokenFile",
+    ) {
+      override def parse(value: String): F[Path] =
+        Path(value).pure
+    }
+
   def ContainerCredentialsRelativeUri[F[_]: Sync]: Setting[F, String] =
     new Setting.Standard[F, String](
       envName = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",


### PR DESCRIPTION
In EKS there is no token in env var `AWS_CONTAINER_AUTHORIZATION_TOKEN`, instead, there's a file containing the token in `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`, this will fall back to getting token from the path referenced in the env var.