### PR TITLE
Cleanup support for `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`

### DIFF
--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -109,6 +109,12 @@ object CredentialsProvider {
     * the contents will be passed as the value of the `Authorization`
     * header when querying the endpoint.
     *
+    * If neither are set, but the `aws.containerAuthorizationTokenFile`
+    * system property, or the `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`
+    * environment variable is set, the contents of the specified file
+    * (with leading and trailing whitespace removed) will be used for
+    * the `Authorization` header when querying the endpoint.
+    *
     * GET requests will be issued to the endpoint and the endpoint is
     * expected to return JSON data in the following format.
     *

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/Setting.scala
@@ -119,7 +119,7 @@ private[aws] object Setting {
         Header.Raw(ci"Authorization", value).pure
     }
 
-  def ContainerAuthorizationTokenFile[F[_]: Async]: Setting[F, Path] =
+  def ContainerAuthorizationTokenFile[F[_]: Sync]: Setting[F, Path] =
     new Setting.Standard[F, Path](
       envName = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
       propName = "aws.containerAuthorizationTokenFile",


### PR DESCRIPTION
Some additional minor cleanup following #42.