### PR TITLE
Add `CredentialsProvider.singleSignOn`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ inThisBuild(
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     startYear := Some(2025),
-    tlBaseVersion := "6.6",
+    tlBaseVersion := "6.7",
     tlCiHeaderCheck := true,
     tlCiScalafixCheck := true,
     tlCiScalafmtCheck := true,

--- a/modules/core/js-jvm/src/main/scala/com/magine/http4s/aws/CredentialsProviderPlatform.scala
+++ b/modules/core/js-jvm/src/main/scala/com/magine/http4s/aws/CredentialsProviderPlatform.scala
@@ -30,8 +30,8 @@ import cats.syntax.all.*
 import com.magine.http4s.aws.internal.AwsAssumedRole
 import com.magine.http4s.aws.internal.AwsConfig
 import com.magine.http4s.aws.internal.AwsCredentialsCache
-import com.magine.http4s.aws.internal.AwsProfileResolved
 import com.magine.http4s.aws.internal.AwsSts
+import com.magine.http4s.aws.internal.AwsStsProfileResolved
 import com.magine.http4s.aws.internal.ExpiringCredentials
 import com.magine.http4s.aws.internal.IniFile
 import com.magine.http4s.aws.internal.Setting.*
@@ -399,7 +399,7 @@ private[aws] trait CredentialsProviderPlatform {
   ): F[CredentialsProvider[F]] =
     for {
       profileName <- Profile.readOrDefault
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -416,7 +416,7 @@ private[aws] trait CredentialsProviderPlatform {
   ): F[CredentialsProvider[F]] =
     for {
       profileName <- Profile.readOrDefault
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -482,7 +482,7 @@ private[aws] trait CredentialsProviderPlatform {
     profileName: AwsProfileName
   ): F[CredentialsProvider[F]] =
     for {
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -499,7 +499,7 @@ private[aws] trait CredentialsProviderPlatform {
     profileName: AwsProfileName
   ): F[CredentialsProvider[F]] =
     for {
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -515,7 +515,7 @@ private[aws] trait CredentialsProviderPlatform {
     tokenCodeProvider: TokenCodeProvider[F]
   ): F[CredentialsProvider[F]] =
     for {
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -533,7 +533,7 @@ private[aws] trait CredentialsProviderPlatform {
     tokenCodeProvider: TokenCodeProvider[F]
   ): F[CredentialsProvider[F]] =
     for {
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFileAsync(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -544,7 +544,7 @@ private[aws] trait CredentialsProviderPlatform {
     } yield securityTokenService
 
   private[aws] def securityTokenService[F[_]](
-    profile: AwsProfileResolved,
+    profile: AwsStsProfileResolved,
     tokenCodeProvider: TokenCodeProvider[F],
     credentialsCache: AwsCredentialsCache[F],
     sts: AwsSts[F]
@@ -557,7 +557,7 @@ private[aws] trait CredentialsProviderPlatform {
     case class Cached(assumedRole: Option[AwsAssumedRole]) extends State
     case class Renewing(deferred: Deferred[F, Result]) extends State
 
-    credentialsCache.read(profile).map(Cached(_)).flatMap(Ref[F].of[State](_)).map { ref =>
+    credentialsCache.readSts(profile).map(Cached(_)).flatMap(Ref[F].of[State](_)).map { ref =>
       new CredentialsProvider[F] {
         sealed trait Action {
           def run(poll: Poll[F]): F[Credentials]

--- a/modules/core/native/src/main/scala/com/magine/http4s/aws/CredentialsProviderPlatform.scala
+++ b/modules/core/native/src/main/scala/com/magine/http4s/aws/CredentialsProviderPlatform.scala
@@ -31,8 +31,8 @@ import cats.syntax.all.*
 import com.magine.http4s.aws.internal.AwsAssumedRole
 import com.magine.http4s.aws.internal.AwsConfig
 import com.magine.http4s.aws.internal.AwsCredentialsCache
-import com.magine.http4s.aws.internal.AwsProfileResolved
 import com.magine.http4s.aws.internal.AwsSts
+import com.magine.http4s.aws.internal.AwsStsProfileResolved
 import com.magine.http4s.aws.internal.ExpiringCredentials
 import com.magine.http4s.aws.internal.IniFile
 import com.magine.http4s.aws.internal.Setting.*
@@ -337,7 +337,7 @@ private[aws] trait CredentialsProviderPlatform {
   ): F[CredentialsProvider[F]] =
     for {
       profileName <- Profile.readOrDefault
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFile(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -403,7 +403,7 @@ private[aws] trait CredentialsProviderPlatform {
     profileName: AwsProfileName
   ): F[CredentialsProvider[F]] =
     for {
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFile(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -419,7 +419,7 @@ private[aws] trait CredentialsProviderPlatform {
     tokenCodeProvider: TokenCodeProvider[F]
   ): F[CredentialsProvider[F]] =
     for {
-      profile <- AwsConfig.default.read(profileName).flatMap(_.resolve)
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSts)
       provider <- credentialsFile(profile.sourceProfile)
       securityTokenService <- securityTokenService(
         profile = profile,
@@ -430,7 +430,7 @@ private[aws] trait CredentialsProviderPlatform {
     } yield securityTokenService
 
   private[aws] def securityTokenService[F[_]](
-    profile: AwsProfileResolved,
+    profile: AwsStsProfileResolved,
     tokenCodeProvider: TokenCodeProvider[F],
     credentialsCache: AwsCredentialsCache[F],
     sts: AwsSts[F]
@@ -443,7 +443,7 @@ private[aws] trait CredentialsProviderPlatform {
     case class Cached(assumedRole: Option[AwsAssumedRole]) extends State
     case class Renewing(deferred: Deferred[F, Result]) extends State
 
-    credentialsCache.read(profile).map(Cached(_)).flatMap(Ref[F].of[State](_)).map { ref =>
+    credentialsCache.readSts(profile).map(Cached(_)).flatMap(Ref[F].of[State](_)).map { ref =>
       new CredentialsProvider[F] {
         sealed trait Action {
           def run(poll: Poll[F]): F[Credentials]

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/CredentialsProvider.scala
@@ -17,7 +17,16 @@
 package com.magine.http4s.aws
 
 import cats.Applicative
+import cats.effect.Async
+import cats.effect.Ref
+import cats.effect.Temporal
 import cats.syntax.all.*
+import com.magine.http4s.aws.internal.AwsConfig
+import com.magine.http4s.aws.internal.AwsCredentialsCache
+import com.magine.http4s.aws.internal.AwsSsoCredentials
+import com.magine.http4s.aws.internal.AwsSsoProfileResolved
+import com.magine.http4s.aws.internal.Setting.Profile
+import java.time.Instant
 
 /**
   * Capability to return [[Credentials]] from one or multiple sources.
@@ -54,6 +63,72 @@ trait CredentialsProvider[F[_]] {
 }
 
 object CredentialsProvider extends CredentialsProviderPlatform {
+  def singleSignOn[F[_]: Async]: F[CredentialsProvider[F]] =
+    for {
+      profileName <- Profile.readOrDefault
+      singleSignOn <- singleSignOn(profileName)
+    } yield singleSignOn
+
+  /**
+    * Returns a new [[CredentialsProvider]] which reads temporary
+    * security credentials from the Single Sign-On (SSO) service.
+    *
+    * This provider integrates with the AWS CLI through:
+    * - reading `~/.aws/config` for profile configuration details,
+    * - reading `~/.aws/cli/cache` for temporary credentials.
+    *
+    * The `~/.aws/config` file is expected to contain a profile entry:
+    * {{{
+    * [profile ...]
+    * sso_session = ...
+    * sso_account_id = ...
+    * sso_role_name = ...
+    * }}}
+    *
+    * The provider will look for cached credentials in `~/.aws/cli/cache`
+    * and cache credentials in memory. Credentials will be returned until
+    * there is 1 minute or less left until the expiration. The provider
+    * does not support refreshing SSO credentials, but will continue to
+    * look for refreshed credentials in `~/.aws/cli/cache` once current
+    * credentials have expired.
+    *
+    * Note the `~/.aws/config` is only read once when the provider is
+    * created, so subsequent updates to the configuration are ignored.
+    */
+  def singleSignOn[F[_]: Async](profileName: AwsProfileName): F[CredentialsProvider[F]] =
+    for {
+      profile <- AwsConfig.default.read(profileName).flatMap(_.resolveSso)
+      credentialsCache = AwsCredentialsCache.default[F]
+      singleSignOn <- singleSignOn(profile, credentialsCache)
+    } yield singleSignOn
+
+  private[aws] def singleSignOn[F[_]](
+    profile: AwsSsoProfileResolved,
+    credentialsCache: AwsCredentialsCache[F]
+  )(
+    implicit F: Temporal[F]
+  ): F[CredentialsProvider[F]] =
+    Ref[F].of(Option.empty[AwsSsoCredentials]).map { ref =>
+      new CredentialsProvider[F] {
+        override def credentials: F[Credentials] =
+          for {
+            now <- Temporal[F].realTime.map(d => Instant.EPOCH.plusNanos(d.toNanos))
+            credentials <- ref.get.flatMap {
+              case Some(cached) if cached.isFresh(now) =>
+                cached.credentials.pure
+              case _ =>
+                for {
+                  cached <- credentialsCache
+                    .readSso(profile)
+                    .map(_.filter(_.isFresh(now)))
+                    .map(_.toRight(MissingCredentials()))
+                    .rethrow
+                  _ <- ref.set(cached.some)
+                } yield cached.credentials
+            }
+          } yield credentials
+      }
+    }
 
   /**
     * Returns a new [[CredentialsProvider]] which always returns

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsAccountId.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsAccountId.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+
+private[aws] final case class AwsAccountId(value: String)
+
+private[aws] object AwsAccountId {
+  implicit val awsAccountIdCodec: Codec[AwsAccountId] =
+    Codec.from(
+      Decoder[String].map(apply),
+      Encoder[String].contramap(_.value)
+    )
+}

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsCredentialsCache.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsCredentialsCache.scala
@@ -41,7 +41,9 @@ import java.nio.charset.StandardCharsets.UTF_8
   * Capability to read and write credentials in `~/.aws/cli/cache`.
   */
 private[aws] trait AwsCredentialsCache[F[_]] {
-  def read(profile: AwsProfileResolved): F[Option[AwsAssumedRole]]
+  def readSts(profile: AwsStsProfileResolved): F[Option[AwsAssumedRole]]
+
+  def readSso(profile: AwsSsoProfileResolved): F[Option[AwsSsoCredentials]]
 
   def write(assumedRole: AwsAssumedRole): F[Unit]
 }
@@ -63,8 +65,8 @@ private[aws] object AwsCredentialsCache {
       private def writeFile(path: Path, json: Json): F[Unit] =
         Stream(json.spaces2).through(files.writeUtf8(path)).compile.drain
 
-      override def read(profile: AwsProfileResolved): F[Option[AwsAssumedRole]] =
-        FileName.fromProfile(profile).flatMap { fileName =>
+      override def readSts(profile: AwsStsProfileResolved): F[Option[AwsAssumedRole]] =
+        FileName.fromStsProfile(profile).flatMap { fileName =>
           cachePath.map(_.resolve(fileName.path)).flatMap { path =>
             implicit val decoder: Decoder[AwsAssumedRole] =
               AwsAssumedRole.decoder(fileName)
@@ -79,6 +81,22 @@ private[aws] object AwsCredentialsCache {
           }
         }
 
+      override def readSso(profile: AwsSsoProfileResolved): F[Option[AwsSsoCredentials]] =
+        FileName.fromSsoProfile(profile).flatMap { fileName =>
+          cachePath.map(_.resolve(fileName.path)).flatMap { path =>
+            implicit val decoder: Decoder[AwsSsoCredentials] =
+              AwsSsoCredentials.decoder(fileName)
+
+            files
+              .readAll(path)
+              .through(utf8.decode)
+              .compile
+              .string
+              .flatMap(decode[AwsSsoCredentials](_).map(_.some).liftTo[F])
+              .recover { case _: NoSuchFileException => none }
+          }
+        }
+
       override def write(assumedRole: AwsAssumedRole): F[Unit] =
         existingCachePath
           .map(_.resolve(assumedRole.cacheFileName.path))
@@ -88,22 +106,26 @@ private[aws] object AwsCredentialsCache {
   def empty[F[_]: Sync]: F[AwsCredentialsCache[F]] =
     Ref[F].of(Map.empty[FileName, AwsAssumedRole]).map(fromRef[F])
 
-  def one[F[_]: Sync](profile: AwsProfileResolved, assumedRole: AwsAssumedRole): F[AwsCredentialsCache[F]] =
+  def one[F[_]: Sync](profile: AwsStsProfileResolved, assumedRole: AwsAssumedRole)
+    : F[AwsCredentialsCache[F]] =
     for {
-      fileName <- FileName.fromProfile(profile)
+      fileName <- FileName.fromStsProfile(profile)
       ref <- Ref[F].of(Map(fileName -> assumedRole))
     } yield fromRef(ref)
 
   def option[F[_]: Sync](
-    profile: AwsProfileResolved,
+    profile: AwsStsProfileResolved,
     assumedRole: Option[AwsAssumedRole]
   ): F[AwsCredentialsCache[F]] =
     assumedRole.map(one(profile, _)).getOrElse(empty)
 
   def fromRef[F[_]: Sync](ref: Ref[F, Map[FileName, AwsAssumedRole]]): AwsCredentialsCache[F] =
     new AwsCredentialsCache[F] {
-      override def read(profile: AwsProfileResolved): F[Option[AwsAssumedRole]] =
-        FileName.fromProfile(profile).flatMap(fileName => ref.get.map(_.get(fileName)))
+      override def readSts(profile: AwsStsProfileResolved): F[Option[AwsAssumedRole]] =
+        FileName.fromStsProfile(profile).flatMap(fileName => ref.get.map(_.get(fileName)))
+
+      override def readSso(profile: AwsSsoProfileResolved): F[Option[AwsSsoCredentials]] =
+        none.pure
 
       override def write(assumedRole: AwsAssumedRole): F[Unit] =
         ref.update(_.updated(assumedRole.cacheFileName, assumedRole))
@@ -124,7 +146,7 @@ private[aws] object AwsCredentialsCache {
       * the same way as done by the `aws` cli, although this
       * is subject to change.
       */
-    def apply[F[_]: Sync](
+    def forSts[F[_]: Sync](
       roleArn: AwsProfile.RoleArn,
       roleSessionName: AwsProfile.RoleSessionName,
       durationSeconds: Option[AwsProfile.DurationSeconds],
@@ -155,12 +177,38 @@ private[aws] object AwsCredentialsCache {
       hash.map(hash => new FileName(Path(s"$hash.json")) {})
     }
 
-    def fromProfile[F[_]: Sync](profile: AwsProfileResolved): F[FileName] =
-      FileName(
+    def forSso[F[_]: Sync](
+      accountId: AwsSsoAccountId,
+      roleName: AwsSsoRoleName,
+      sessionName: AwsSsoSessionName
+    ): F[FileName] = {
+      val json =
+        JsonObject
+          .fromIterable(
+            List(
+              Some("accountId" -> accountId.value.asJson),
+              Some("roleName" -> roleName.value.asJson),
+              Some("sessionName" -> sessionName.value.asJson)
+            ).flatten
+          )
+          .toJson
+
+      sha1Hex(json.noSpaces).map(hash => new FileName(Path(s"$hash.json")) {})
+    }
+
+    def fromStsProfile[F[_]: Sync](profile: AwsStsProfileResolved): F[FileName] =
+      FileName.forSts(
         roleArn = profile.roleArn,
         roleSessionName = profile.roleSessionName,
         durationSeconds = profile.durationSeconds,
         mfaSerial = profile.mfaSerial
+      )
+
+    def fromSsoProfile[F[_]: Sync](profile: AwsSsoProfileResolved): F[FileName] =
+      FileName.forSso(
+        accountId = profile.ssoAccountId,
+        roleName = profile.ssoRoleName,
+        sessionName = profile.ssoSessionName
       )
 
     private def sha1Hex[F[_]: Sync](s: String): F[String] =

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsProfile.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsProfile.scala
@@ -34,12 +34,18 @@ private[aws] final case class AwsProfile(
   roleArn: Option[AwsProfile.RoleArn],
   roleSessionName: Option[AwsProfile.RoleSessionName],
   durationSeconds: Option[AwsProfile.DurationSeconds],
-  sourceProfile: AwsProfileName,
-  mfaSerial: MfaSerial,
-  region: Option[Region]
+  sourceProfile: Option[AwsProfileName],
+  mfaSerial: Option[MfaSerial],
+  region: Option[Region],
+  ssoAccountId: Option[AwsSsoAccountId],
+  ssoRoleName: Option[AwsSsoRoleName],
+  ssoSessionName: Option[AwsSsoSessionName]
 ) {
-  def resolve[F[_]: Sync]: F[AwsProfileResolved] =
-    AwsProfileResolved.fromProfile(this)
+  def resolveSts[F[_]: Sync]: F[AwsStsProfileResolved] =
+    AwsStsProfileResolved.fromProfile(this)
+
+  def resolveSso[F[_]: Sync]: F[AwsSsoProfileResolved] =
+    AwsSsoProfileResolved.fromProfile(this)
 }
 
 private[aws] object AwsProfile {
@@ -86,9 +92,12 @@ private[aws] object AwsProfile {
       decode.optional("role_arn", RoleArn(_).asRight),
       decode.optional("role_session_name", RoleSessionName(_).asRight),
       decode.optional("duration_seconds", DurationSeconds.parse(_)),
-      decode.required("source_profile", AwsProfileName(_).asRight),
-      decode.required("mfa_serial", MfaSerial(_).asRight),
-      decode.optional("region", Region.parse(_))
+      decode.optional("source_profile", AwsProfileName(_).asRight),
+      decode.optional("mfa_serial", MfaSerial(_).asRight),
+      decode.optional("region", Region.parse(_)),
+      decode.optional("sso_account_id", AwsSsoAccountId(_).asRight),
+      decode.optional("sso_role_name", AwsSsoRoleName(_).asRight),
+      decode.optional("sso_session", AwsSsoSessionName(_).asRight)
     ).mapN(apply).toEither.leftMap(parseError(profileName))
   }
 

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoAccountId.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoAccountId.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+private[aws] final case class AwsSsoAccountId(value: String)

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoCredentials.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoCredentials.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+import com.magine.http4s.aws.Credentials
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax.*
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+private[aws] final case class AwsSsoCredentials(
+  accountId: AwsAccountId,
+  credentials: Credentials,
+  expiration: Instant,
+  cacheFileName: AwsCredentialsCache.FileName
+) {
+  def isFresh(now: Instant): Boolean =
+    now.plus(1, ChronoUnit.MINUTES).isBefore(expiration)
+}
+
+private[aws] object AwsSsoCredentials {
+  def decoder(cacheFileName: AwsCredentialsCache.FileName): Decoder[AwsSsoCredentials] =
+    Decoder.instance { c =>
+      for {
+        accountId <- c.downField("Credentials").get[AwsAccountId]("AccountId")
+        accessKeyId <- c.downField("Credentials").get[Credentials.AccessKeyId]("AccessKeyId")
+        secretAccessKey <- c.downField("Credentials").get[Credentials.SecretAccessKey]("SecretAccessKey")
+        sessionToken <- c.downField("Credentials").get[Credentials.SessionToken]("SessionToken")
+        expirationField = c.downField("Credentials").downField("Expiration")
+        expirationEpochSecond = expirationField.as[Long].map(Instant.ofEpochSecond)
+        expirationIso8601 = expirationField.as(Iso8601.decoder)
+        expiration <- expirationEpochSecond.orElse(expirationIso8601)
+      } yield AwsSsoCredentials(
+        accountId = accountId,
+        credentials = Credentials(
+          accessKeyId = accessKeyId,
+          secretAccessKey = secretAccessKey,
+          sessionToken = Some(sessionToken)
+        ),
+        expiration = expiration,
+        cacheFileName = cacheFileName
+      )
+    }
+
+  implicit val awsSsoCredentialsEncoder: Encoder[AwsSsoCredentials] =
+    Encoder.instance { sso =>
+      Json.obj(
+        "ProviderType" -> "sso".asJson,
+        "Credentials" -> Json.obj(
+          "AccessKeyId" -> sso.credentials.accessKeyId.asJson,
+          "SecretAccessKey" -> sso.credentials.secretAccessKey.asJson,
+          "SessionToken" -> sso.credentials.sessionToken.asJson,
+          "Expiration" -> sso.expiration.asJson,
+          "AccountId" -> sso.accountId.asJson
+        ),
+      )
+    }
+}

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoProfileResolved.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoProfileResolved.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+import cats.effect.Sync
+import cats.syntax.all.*
+import com.magine.http4s.aws.AwsProfileName
+
+private[aws] final case class AwsSsoProfileResolved(
+  profileName: AwsProfileName,
+  ssoAccountId: AwsSsoAccountId,
+  ssoRoleName: AwsSsoRoleName,
+  ssoSessionName: AwsSsoSessionName
+)
+
+private[aws] object AwsSsoProfileResolved {
+  def fromProfile[F[_]: Sync](profile: AwsProfile): F[AwsSsoProfileResolved] =
+    for {
+      ssoAccountId <- profile.ssoAccountId.liftTo[F](missing("sso_account_id", profile))
+      ssoRoleName <- profile.ssoRoleName.liftTo[F](missing("sso_role_name", profile))
+      ssoSessionName <- profile.ssoSessionName.liftTo[F](missing("sso_session", profile))
+    } yield AwsSsoProfileResolved(
+      profileName = profile.profileName,
+      ssoAccountId = ssoAccountId,
+      ssoRoleName = ssoRoleName,
+      ssoSessionName = ssoSessionName,
+    )
+
+  private def missing(key: String, profile: AwsProfile): Throwable =
+    new RuntimeException(s"Missing $key for profile ${profile.profileName.value}")
+}

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoRoleName.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoRoleName.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+private[aws] final case class AwsSsoRoleName(value: String)

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoSessionName.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSsoSessionName.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Magine Pro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.magine.http4s.aws.internal
+
+private[aws] final case class AwsSsoSessionName(value: String)

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSts.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsSts.scala
@@ -92,15 +92,16 @@ private[aws] object AwsSts {
 
         request.toResource.flatMap(client.run).use {
           case Successful(response) =>
-            AwsCredentialsCache.FileName[F](roleArn, roleSessionName, durationSeconds, mfaSerial).flatMap {
-              cacheFileName =>
+            AwsCredentialsCache.FileName
+              .forSts[F](roleArn, roleSessionName, durationSeconds, mfaSerial)
+              .flatMap { cacheFileName =>
                 AssumeRoleResponse
                   .entityDecoder(cacheFileName)
                   .decode(response, strict = false)
                   .leftWiden[Throwable]
                   .rethrowT
                   .map(_.value)
-            }
+              }
 
           case response =>
             AssumeRoleErrorResponse.entityDecoder

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsStsProfileResolved.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/AwsStsProfileResolved.scala
@@ -30,7 +30,7 @@ import com.magine.http4s.aws.MfaSerial
   * combining the configuration file, some system properties,
   * some environment variables, and some default values.
   */
-private[aws] final case class AwsProfileResolved(
+private[aws] final case class AwsStsProfileResolved(
   profileName: AwsProfileName,
   roleArn: AwsProfile.RoleArn,
   roleSessionName: AwsProfile.RoleSessionName,
@@ -40,24 +40,26 @@ private[aws] final case class AwsProfileResolved(
   region: Region
 )
 
-private[aws] object AwsProfileResolved {
-  def fromProfile[F[_]: Sync](profile: AwsProfile): F[AwsProfileResolved] =
+private[aws] object AwsStsProfileResolved {
+  def fromProfile[F[_]: Sync](profile: AwsProfile): F[AwsStsProfileResolved] =
     for {
+      mfaSerial <- profile.mfaSerial.liftTo[F](missing("mfa_serial", profile))
+      sourceProfile <- profile.sourceProfile.liftTo[F](missing("source_profile", profile))
       roleArn <- resolveRoleArn(profile)
       roleSessionName <- resolveRoleSessionName(profile)
       region <- resolveRegion(profile)
-    } yield AwsProfileResolved(
+    } yield AwsStsProfileResolved(
       profileName = profile.profileName,
       roleArn = roleArn,
       roleSessionName = roleSessionName,
       durationSeconds = profile.durationSeconds,
-      sourceProfile = profile.sourceProfile,
-      mfaSerial = profile.mfaSerial,
+      sourceProfile = sourceProfile,
+      mfaSerial = mfaSerial,
       region = region
     )
 
   private def resolveRoleArn[F[_]: Sync](profile: AwsProfile): F[AwsProfile.RoleArn] =
-    Setting.RoleArn.read.flatMap(_.orElse(profile.roleArn).toRight(missingRoleArn(profile)).liftTo[F])
+    Setting.RoleArn.read.flatMap(_.orElse(profile.roleArn).toRight(missing("role_arn", profile)).liftTo[F])
 
   private def resolveRoleSessionName[F[_]: Sync](profile: AwsProfile): F[AwsProfile.RoleSessionName] =
     Setting.RoleSessionName.read
@@ -67,11 +69,8 @@ private[aws] object AwsProfileResolved {
   private def resolveRegion[F[_]: Sync](profile: AwsProfile): F[Region] =
     Setting.Region.read
       .flatMap(_.map(_.some.pure).getOrElse(Setting.DefaultRegion.read))
-      .flatMap(_.orElse(profile.region).toRight(missingRegion(profile)).liftTo[F])
+      .flatMap(_.orElse(profile.region).toRight(missing("region", profile)).liftTo[F])
 
-  private def missingRoleArn(profile: AwsProfile): Throwable =
-    new RuntimeException(s"Missing role_arn for profile ${profile.profileName.value}")
-
-  private def missingRegion(profile: AwsProfile): Throwable =
-    new RuntimeException(s"Missing region for profile ${profile.profileName.value}")
+  private def missing(key: String, profile: AwsProfile): Throwable =
+    new RuntimeException(s"Missing $key for profile ${profile.profileName.value}")
 }

--- a/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/IniFile.scala
+++ b/modules/core/shared/src/main/scala/com/magine/http4s/aws/internal/IniFile.scala
@@ -42,16 +42,16 @@ private[aws] object IniFile {
 
   private val parser: P0[IniFile] = {
     val whitespace0 = P.char(' ').rep0.void
-    val newlines0 = P.char('\n').rep0.void
-    val newlines = P.char('\n').rep.void
+    val newlines0 = P.charIn('\r', '\n').rep0.void
+    val newlines = P.charIn('\r', '\n').rep.void
 
     val comment =
-      (P.char('#') *> P.charsWhile(_ != '\n'))
+      (P.char('#') *> P.charsWhile(c => c != '\r' && c != '\n'))
         .surroundedBy(whitespace0)
         .void
 
-    val name = P.charsWhile(c => c != '=' && c != '\n').map(_.trim)
-    val value = P.charsWhile0(c => c != '\n').map(_.trim)
+    val name = P.charsWhile(c => c != '=' && c != '\r' && c != '\n').map(_.trim)
+    val value = P.charsWhile0(c => c != '\r' && c != '\n').map(_.trim)
     val key = ((name <* P.char('=')) ~ value).map((Key(_, _)).tupled)
 
     val keys =

--- a/modules/core/shared/src/test/scala/com/magine/http4s/aws/CredentialsProviderSuite.scala
+++ b/modules/core/shared/src/test/scala/com/magine/http4s/aws/CredentialsProviderSuite.scala
@@ -37,7 +37,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
   test("securityTokenService.cacheEmpty") {
     val gen =
       for {
-        profile <- awsProfileResolvedGen
+        profile <- awsStsProfileResolvedGen
         tokenCode <- tokenCodeGen
         assumedRoleFresh <- awsAssumedRoleFreshGen(profile)
       } yield (profile, tokenCode, assumedRoleFresh)
@@ -59,7 +59,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
                 sts = sts(assumedRoleFresh)
               )
               credentials <- provider.credentials
-              cached <- credentialsCache.read(profile)
+              cached <- credentialsCache.readSts(profile)
               _ <- IO(assertEquals(cached, assumedRoleFresh.some))
             } yield credentials
           }
@@ -71,7 +71,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
   test("securityTokenService.cacheFresh") {
     val gen =
       for {
-        profile <- awsProfileResolvedGen
+        profile <- awsStsProfileResolvedGen
         assumedRoleFresh <- awsAssumedRoleFreshGen(profile)
       } yield (profile, assumedRoleFresh)
 
@@ -88,7 +88,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
               sts = stsError
             )
             credentials <- provider.credentials
-            cached <- credentialsCache.read(profile)
+            cached <- credentialsCache.readSts(profile)
             _ <- IO(assertEquals(cached, assumedRoleFresh.some))
           } yield credentials
         }
@@ -100,7 +100,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
   test("securityTokenService.cacheStale") {
     val gen =
       for {
-        profile <- awsProfileResolvedGen
+        profile <- awsStsProfileResolvedGen
         tokenCode <- tokenCodeGen
         assumedRoleStale <- Gen.oneOf(
           awsAssumedRoleStaleGen(profile),
@@ -127,7 +127,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
                 sts = sts(assumedRoleFresh)
               )
               credentials <- provider.credentials
-              cached <- credentialsCache.read(profile)
+              cached <- credentialsCache.readSts(profile)
               _ <- IO(assertEquals(cached, assumedRoleFresh.some))
             } yield credentials
           }
@@ -139,7 +139,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
   test("securityTokenService.renewCanceled") {
     val gen =
       for {
-        profile <- awsProfileResolvedGen
+        profile <- awsStsProfileResolvedGen
         tokenCode <- tokenCodeGen
         assumedRoleStale <- Gen.option(
           Gen.oneOf(
@@ -183,7 +183,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
   test("securityTokenService.renewError") {
     val gen =
       for {
-        profile <- awsProfileResolvedGen
+        profile <- awsStsProfileResolvedGen
         assumedRoleStale <- Gen.option(
           Gen.oneOf(
             awsAssumedRoleStaleGen(profile),
@@ -218,7 +218,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
   test("securityTokenService.renewOnce") {
     val gen =
       for {
-        profile <- awsProfileResolvedGen
+        profile <- awsStsProfileResolvedGen
         tokenCode <- tokenCodeGen
         assumedRoleStale <- Gen.option(
           Gen.oneOf(
@@ -250,7 +250,7 @@ final class CredentialsProviderSuite extends CatsEffectSuite with ScalaCheckEffe
               )
               credentials <- List.fill(100)(provider.credentials).parSequence
               _ <- IO(assert(credentials.forall(_ == assumedRoleFresh.credentials)))
-              cached <- credentialsCache.read(profile)
+              cached <- credentialsCache.readSts(profile)
               _ <- IO(assertEquals(cached, assumedRoleFresh.some))
             } yield ()
           }

--- a/modules/core/shared/src/test/scala/com/magine/http4s/aws/package.scala
+++ b/modules/core/shared/src/test/scala/com/magine/http4s/aws/package.scala
@@ -21,7 +21,10 @@ import com.magine.aws.Region
 import com.magine.http4s.aws.internal.AwsAssumedRole
 import com.magine.http4s.aws.internal.AwsCredentialsCache
 import com.magine.http4s.aws.internal.AwsProfile
-import com.magine.http4s.aws.internal.AwsProfileResolved
+import com.magine.http4s.aws.internal.AwsSsoAccountId
+import com.magine.http4s.aws.internal.AwsSsoRoleName
+import com.magine.http4s.aws.internal.AwsSsoSessionName
+import com.magine.http4s.aws.internal.AwsStsProfileResolved
 import java.time.Instant
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
@@ -64,15 +67,36 @@ package object aws {
   implicit val awsProfileNameArbitrary: Arbitrary[AwsProfileName] =
     Arbitrary(awsProfileNameGen)
 
+  val awsSsoAccountIdGen: Gen[AwsSsoAccountId] =
+    arbitrary[String].map(AwsSsoAccountId(_))
+
+  implicit val awsSsoAccountIdArbitrary: Arbitrary[AwsSsoAccountId] =
+    Arbitrary(awsSsoAccountIdGen)
+
+  val awsSsoRoleNameGen: Gen[AwsSsoRoleName] =
+    arbitrary[String].map(AwsSsoRoleName(_))
+
+  implicit val awsSsoRoleNameArbitrary: Arbitrary[AwsSsoRoleName] =
+    Arbitrary(awsSsoRoleNameGen)
+
+  val awsSsoSessionNameGen: Gen[AwsSsoSessionName] =
+    arbitrary[String].map(AwsSsoSessionName(_))
+
+  implicit val awsSsoSessionNameArbitrary: Arbitrary[AwsSsoSessionName] =
+    Arbitrary(awsSsoSessionNameGen)
+
   val awsProfileGen: Gen[AwsProfile] =
     for {
       profileName <- arbitrary[AwsProfileName]
       roleArn <- arbitrary[Option[AwsProfile.RoleArn]]
       roleSessionName <- arbitrary[Option[AwsProfile.RoleSessionName]]
       durationSeconds <- arbitrary[Option[AwsProfile.DurationSeconds]]
-      sourceProfile <- arbitrary[AwsProfileName]
-      mfaSerial <- arbitrary[MfaSerial]
+      sourceProfile <- arbitrary[Option[AwsProfileName]]
+      mfaSerial <- arbitrary[Option[MfaSerial]]
       region <- arbitrary[Option[Region]]
+      ssoAccountId <- arbitrary[Option[AwsSsoAccountId]]
+      ssoRoleName <- arbitrary[Option[AwsSsoRoleName]]
+      ssoSessionName <- arbitrary[Option[AwsSsoSessionName]]
     } yield AwsProfile(
       profileName = profileName,
       roleArn = roleArn,
@@ -80,13 +104,16 @@ package object aws {
       durationSeconds = durationSeconds,
       sourceProfile = sourceProfile,
       mfaSerial = mfaSerial,
-      region = region
+      region = region,
+      ssoAccountId = ssoAccountId,
+      ssoRoleName = ssoRoleName,
+      ssoSessionName = ssoSessionName
     )
 
   implicit val awsProfileArbitrary: Arbitrary[AwsProfile] =
     Arbitrary(awsProfileGen)
 
-  val awsProfileResolvedGen: Gen[AwsProfileResolved] =
+  val awsStsProfileResolvedGen: Gen[AwsStsProfileResolved] =
     for {
       profileName <- arbitrary[AwsProfileName]
       roleArn <- arbitrary[AwsProfile.RoleArn]
@@ -95,7 +122,7 @@ package object aws {
       sourceProfile <- arbitrary[AwsProfileName]
       mfaSerial <- arbitrary[MfaSerial]
       region <- arbitrary[Region]
-    } yield AwsProfileResolved(
+    } yield AwsStsProfileResolved(
       profileName = profileName,
       roleArn = roleArn,
       roleSessionName = roleSessionName,
@@ -105,8 +132,8 @@ package object aws {
       region = region
     )
 
-  implicit val awsProfileResolvedArbitrary: Arbitrary[AwsProfileResolved] =
-    Arbitrary(awsProfileResolvedGen)
+  implicit val awsStsProfileResolvedArbitrary: Arbitrary[AwsStsProfileResolved] =
+    Arbitrary(awsStsProfileResolvedGen)
 
   val awsServiceNameGen: Gen[AwsServiceName] =
     arbitrary[String].map(AwsServiceName(_))
@@ -147,11 +174,11 @@ package object aws {
     Arbitrary(credentialsGen)
 
   /* The effect here is to capture `Hashing` possibly being unavailable. */
-  def awsCredentialsCacheFileName(profile: AwsProfileResolved): AwsCredentialsCache.FileName =
-    AwsCredentialsCache.FileName.fromProfile[SyncIO](profile).unsafeRunSync()
+  def awsCredentialsCacheFileName(profile: AwsStsProfileResolved): AwsCredentialsCache.FileName =
+    AwsCredentialsCache.FileName.fromStsProfile[SyncIO](profile).unsafeRunSync()
 
   val awsCredentialsCacheFileNameGen: Gen[AwsCredentialsCache.FileName] =
-    arbitrary[AwsProfileResolved].flatMap(awsCredentialsCacheFileName(_))
+    arbitrary[AwsStsProfileResolved].flatMap(awsCredentialsCacheFileName(_))
 
   implicit val awsCredentialsCacheFileNameArbitrary: Arbitrary[AwsCredentialsCache.FileName] =
     Arbitrary(awsCredentialsCacheFileNameGen)
@@ -168,7 +195,7 @@ package object aws {
   implicit val awsAssumedRoleAssumedRoleArnArbitrary: Arbitrary[AwsAssumedRole.AssumedRoleArn] =
     Arbitrary(awsAssumedRoleAssumedRoleArnGen)
 
-  def awsAssumedRoleGen(expiration: Instant, profile: AwsProfileResolved): Gen[AwsAssumedRole] =
+  def awsAssumedRoleGen(expiration: Instant, profile: AwsStsProfileResolved): Gen[AwsAssumedRole] =
     for {
       credentials <- arbitrary[Credentials]
       cacheFileName = awsCredentialsCacheFileName(profile)
@@ -183,7 +210,7 @@ package object aws {
     )
 
   /** AwsAssumedRole#isFresh will be `true` at epoch start. */
-  def awsAssumedRoleFreshGen(profile: AwsProfileResolved): Gen[AwsAssumedRole] =
+  def awsAssumedRoleFreshGen(profile: AwsStsProfileResolved): Gen[AwsAssumedRole] =
     for {
       expiration <- Gen
         .chooseNum(61L, Instant.MAX.getEpochSecond)
@@ -192,7 +219,7 @@ package object aws {
     } yield assumedRole
 
   /** AwsAssumedRole#isFresh will be `false` at epoch start but credentials active. */
-  def awsAssumedRoleStaleGen(profile: AwsProfileResolved): Gen[AwsAssumedRole] =
+  def awsAssumedRoleStaleGen(profile: AwsStsProfileResolved): Gen[AwsAssumedRole] =
     for {
       expiration <- Gen
         .chooseNum(1L, 60L)
@@ -201,7 +228,7 @@ package object aws {
     } yield assumedRole
 
   /** AwsAssumedRole#isFresh will be `false` at epoch start and credentials expired. */
-  def awsAssumedRoleExpiredGen(profile: AwsProfileResolved): Gen[AwsAssumedRole] =
+  def awsAssumedRoleExpiredGen(profile: AwsStsProfileResolved): Gen[AwsAssumedRole] =
     for {
       expiration <- Gen
         .chooseNum(Instant.MIN.getEpochSecond, 0L)
@@ -212,7 +239,7 @@ package object aws {
   val awsAssumedRoleGen: Gen[AwsAssumedRole] =
     for {
       expiration <- arbitrary[Instant]
-      profile <- arbitrary[AwsProfileResolved]
+      profile <- arbitrary[AwsStsProfileResolved]
       assumedRole <- awsAssumedRoleGen(expiration, profile)
     } yield assumedRole
 


### PR DESCRIPTION
Add `CredentialsProvider.singleSignOn` for reading temporary SSO credentials stored by the AWS CLI.